### PR TITLE
feat: show error when run in non-main directory

### DIFF
--- a/internal/server/compiler/compiler.go
+++ b/internal/server/compiler/compiler.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 )
 
+var wasmFilePrefix = []byte("\x00asm")
+
 func BuildMainWasm() ([]byte, error) {
 	outputPath := filepath.Join(tmpDir, "main.wasm")
 
@@ -50,6 +52,12 @@ func BuildMainWasm() ([]byte, error) {
 	content, err := os.ReadFile(outputPath)
 	if err != nil {
 		return nil, fmt.Errorf("Problem reading file %s: %w", outputPath, err)
+	}
+
+	// ensure real WASM was created
+	if !bytes.HasPrefix(content, wasmFilePrefix) {
+		workdir, _ := os.Getwd()
+		return nil, fmt.Errorf("Package main not found in the current working directory: %s", workdir)
 	}
 
 	return content, nil


### PR DESCRIPTION
Show an error when package main cannot be found in the current working directory.

This commit is a workaround for `go build` limitations which does not show errors in such case.