### PR TITLE
feat: make go build command configurable

### DIFF
--- a/internal/server/file.go
+++ b/internal/server/file.go
@@ -21,13 +21,18 @@ var wasmExecJS = wasmexecjs.Get()
 
 var ErrNotFound = errors.New("not found")
 
-func GetFile(file string) ([]byte, error) {
+var (
+	GoBuild        *string
+	ReleaseGoBuild *string
+)
+
+func GetFile(file string, goBuild string) ([]byte, error) {
 	if file == "wasm_exec.js" {
 		return wasmExecJS, nil
 	}
 
 	if file == "main.wasm" {
-		return compiler.BuildMainWasm()
+		return compiler.BuildMainWasm(goBuild)
 	}
 
 	workdir, _ := os.Getwd()

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -33,7 +33,7 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 		file = "index.html"
 	}
 
-	content, err := GetFile(file)
+	content, err := GetFile(file, *GoBuild)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			writer.WriteHeader(404)

--- a/internal/server/release.go
+++ b/internal/server/release.go
@@ -21,7 +21,7 @@ func ReleaseZip() ([]byte, error) {
 	}
 
 	for _, file := range files {
-		content, err := GetFile(file)
+		content, err := GetFile(file, *ReleaseGoBuild)
 		if err != nil {
 			return nil, fmt.Errorf("getting file failed: %w", err)
 		}

--- a/piweb.go
+++ b/piweb.go
@@ -3,6 +3,11 @@
 
 package piweb
 
+var (
+	GoBuild        = "go build -buildvcs=false -o {{.Output}} ." // executed on each webpage refresh.
+	ReleaseGoBuild = "go build -o {{.Output}} ."                 // executed when creating release build.
+)
+
 func Run() {
 	run()
 }

--- a/piweb_desktop.go
+++ b/piweb_desktop.go
@@ -17,5 +17,8 @@ func run() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	defer stop()
 
+	server.GoBuild = &GoBuild
+	server.ReleaseGoBuild = &ReleaseGoBuild
+
 	server.Start(ctx, 8080)
 }


### PR DESCRIPTION
`go build` command can be now customized by changing piweb.GoBuild and piweb.ReleaseGoBuild.

By default, piweb.GoBuild does not build VCS, which can improve build time drastically on Windows.